### PR TITLE
Update which PR is used by tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: ./
         with:
           repository: myyk/git-democracy
-          issueNumber: 11
+          issueNumber: 71 # this is a permenant PR left for testing


### PR DESCRIPTION
Previously, was using a closed PR but since now the vote closes on closed PRs, that method of testing will not continue to work. So, now we're using a PR that will just be left open always.