### PR TITLE
ci: fix release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+name: release-please
+
 on:
   push:
     branches:
@@ -7,24 +9,26 @@ permissions:
   contents: write
   pull-requests: write
 
-name: release-please
-
 jobs:
   release-please:
+    name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - name: Run Release Please
+        uses: google-github-actions/release-please-action@v3
         with:
           release-type: simple
           package-name: git-democracy
-          command: github-release
-      - uses: actions/checkout@v4
-      - name: tag major and minor versions
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/google-github-actions/release-please-action.git"
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ env.GITHUB_REPOSITORY}}.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true


### PR DESCRIPTION
This should do the trick. Essentially, release please will run every time something is merged on `main`, for every `fix` and `feat` commits, it will generate a PR with the version. 

Then upon merging this PR onto `main`, it will run the Release Please workflow again, this time creating the tags and the GitHub release. 

(The setup is a little annoying, but once setup, we never have to look back at it again :))